### PR TITLE
[Feat] 소비내역 태그가 하나있을때 가운데로 오는 버그 수정

### DIFF
--- a/lib/widget/income_card.dart
+++ b/lib/widget/income_card.dart
@@ -91,19 +91,25 @@ class IncomeCard extends StatelessWidget {
             //       ),
             //     ],
             //   )
-            Wrap(
-              direction: Axis.horizontal,
-              alignment: WrapAlignment.start,
-              spacing: 8.0,
-              runSpacing: 4.0,
-              children: [
-                for (int i = 0; i < money.tagList.length; i++)
-                  Padding(
-                    padding: const EdgeInsets.only(right: 4.0),
-                    child: LabelWidget(
-                        money.tagList[i].name, Color(money.tagList[i].color)),
-                  ),
-              ],
+            Container(
+              width: double.infinity,
+              child: Padding(
+                padding: const EdgeInsets.only(left: 20),
+                child: Wrap(
+                  direction: Axis.horizontal,
+                  alignment: WrapAlignment.start,
+                  spacing: 8.0,
+                  runSpacing: 4.0,
+                  children: [
+                    for (int i = 0; i < money.tagList.length; i++)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 4.0),
+                        child: LabelWidget(money.tagList[i].name,
+                            Color(money.tagList[i].color)),
+                      ),
+                  ],
+                ),
+              ),
             ),
             // Container(
             //   height: 26,


### PR DESCRIPTION

<img width="411" alt="스크린샷 2024-05-14 오후 2 29 42" src="https://github.com/three523/devu/assets/71269216/cb865b16-9dda-42ad-8d31-97db05c2e641">
</br>
수정전

<img width="407" alt="스크린샷 2024-05-14 오후 2 29 15" src="https://github.com/three523/devu/assets/71269216/dc17e3bd-883a-49c1-85a5-a9c62367a070"> 
</br>
수정후
